### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -36,48 +36,63 @@ jobs:
           - fqbn: arduino:avr:nano
             platforms: |
               - name: arduino:avr
+            artifact-name-suffix: arduino-avr-nano
           - fqbn: arduino:avr:mega
             platforms: |
               - name: arduino:avr
+            artifact-name-suffix: arduino-avr-mega
           - fqbn: arduino:avr:leonardo
             platforms: |
               - name: arduino:avr
+            artifact-name-suffix: arduino-avr-leonardo
           - fqbn: arduino:avr:yun
             platforms: |
               - name: arduino:avr
+            artifact-name-suffix: arduino-avr-yun
           - fqbn: arduino:megaavr:uno2018
             platforms: |
               - name: arduino:megaavr
+            artifact-name-suffix: arduino-megaavr-uno2018
           - fqbn: arduino:megaavr:nona4809
             platforms: |
               - name: arduino:megaavr
+            artifact-name-suffix: arduino-megaavr-nona4809
           - fqbn: arduino:sam:arduino_due_x_dbg
             platforms: |
               - name: arduino:sam
+            artifact-name-suffix: arduino-sam-arduino_due_x_dbg
           - fqbn: arduino:samd:arduino_zero_edbg
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-arduino_zero_edbg
           - fqbn: arduino:samd:mkrzero
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrzero
           - fqbn: arduino:samd:nano_33_iot
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-nano_33_iot
           - fqbn: arduino:mbed_portenta:envie_m7:target_core=cm4
             platforms: |
               - name: arduino:mbed_portenta
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7-target_core-cm4
           - fqbn: arduino:mbed_portenta:envie_m7
             platforms: |
               - name: arduino:mbed_portenta
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7
           - fqbn: arduino:mbed_edge:edge_control
             platforms: |
               - name: arduino:mbed_edge
+            artifact-name-suffix: arduino-mbed_edge-edge_control
           - fqbn: arduino:mbed_nano:nano33ble
             platforms: |
               - name: arduino:mbed_nano
+            artifact-name-suffix: arduino-mbed_nano-nano33ble
           - fqbn: arduino:mbed_nano:nanorp2040connect
             platforms: |
               - name: arduino:mbed_nano
+            artifact-name-suffix: arduino-mbed_nano-nanorp2040connect
 
     steps:
       - name: Checkout repository
@@ -104,4 +119,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .